### PR TITLE
Mejora en los permisos del home de los usuarios y su shell

### DIFF
--- a/defaults/main/usuarios_innecesarios.yml
+++ b/defaults/main/usuarios_innecesarios.yml
@@ -24,3 +24,6 @@ shell_usuarios:
   - { user: 'root', shell: '/bin/bash' }
   - { user: 'shutdown', shell: '/sbin/shutdown' }
   - { user: 'halt', shell: '/sbin/halt' }
+
+shell_usuarios_especificos:
+#  - { user: 'usuario_especifico', shell: '/sbin/nologin'}

--- a/tasks/limites_permisos_y_cad_claves.yml
+++ b/tasks/limites_permisos_y_cad_claves.yml
@@ -95,5 +95,5 @@
   ansible.builtin.file:
     path: "{{ item.stdout }}"
     state: directory
-    mode: "g-rwx,o-rwx"
+    mode: "g-wx,o-rwx"
   with_items: "{{ users_home_list.results }}"

--- a/tasks/usuarios_innecesarios.yml
+++ b/tasks/usuarios_innecesarios.yml
@@ -48,6 +48,16 @@
   ansible.builtin.user:
     name: "{{ item }}"
     shell: "/bin/bash"
-  loop: "{{ usuarios_normales.stdout_lines }}"
+  with_items: "{{ usuarios_normales.stdout_lines | difference(shell_usuarios_especificos | map('dict2items') | flatten | selectattr('key', '==', 'user') | map(attribute='value')) }}"
+  notify:
+    - Reiniciar_host
+
+- name: Asignar la shell específica a usuarios con UID >= 1000
+  become: true
+  ansible.builtin.user:
+    name: "{{ item.user }}"
+    shell: "{{ item.shell }}"
+  with_items: "{{ shell_usuarios_especificos }}"
+  when: shell_usuarios_especificos is defined and shell_usuarios_especificos != None
   notify:
     - Reiniciar_host


### PR DESCRIPTION
Se reconfiguran los permisos de los home de los usuarios para cumplir con la auditoría que realiza CLARA y con lo indicado en la guía.

Se permite definir la shell en concreto de una serie de usuarios específicos.